### PR TITLE
Add unit tests for star rendering, moon texture, and update visual tests

### DIFF
--- a/tests/test_moon_texture.py
+++ b/tests/test_moon_texture.py
@@ -1,0 +1,180 @@
+"""Unit tests for moon surface texture loading and sampling (moon_texture.py).
+
+Tests cover texture loading, bilinear UV sampling, edge cases, and
+fallback behaviour.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from render.moon_texture import load_texture, sample_texture
+
+
+# ── Texture loading ───────────────────────────────────────────
+
+class TestTextureLoading:
+    """Verify the bundled moon texture loads correctly."""
+
+    def test_texture_loads_without_error(self):
+        """Texture should load without raising."""
+        tex = load_texture()
+        assert tex is not None
+
+    def test_texture_is_numpy_array(self):
+        """Loaded texture should be a numpy uint8 array."""
+        tex = load_texture()
+        assert isinstance(tex, np.ndarray)
+        assert tex.dtype == np.uint8
+
+    def test_texture_is_3_channel(self):
+        """Texture should have 3 colour channels (RGB)."""
+        tex = load_texture()
+        assert tex.ndim == 3
+        assert tex.shape[2] == 3
+
+    def test_texture_has_correct_dimensions(self):
+        """Texture should be 512×256 (width×height)."""
+        tex = load_texture()
+        assert tex.shape[1] == 512, f"Expected width 512, got {tex.shape[1]}"
+        assert tex.shape[0] == 256, f"Expected height 256, got {tex.shape[0]}"
+
+    def test_texture_has_valid_pixel_data(self):
+        """Pixel values should be in valid uint8 range."""
+        tex = load_texture()
+        assert tex.min() >= 0
+        assert tex.max() <= 255
+
+    def test_texture_not_all_same(self):
+        """Texture should not be a solid colour (has actual lunar data)."""
+        tex = load_texture()
+        assert tex.max() > tex.min(), "Texture appears to be a solid colour"
+
+    def test_texture_is_cached(self):
+        """Loading multiple times should return the same object."""
+        tex1 = load_texture()
+        tex2 = load_texture()
+        assert tex1 is tex2
+
+    def test_missing_file_returns_none(self):
+        """Loading from a non-existent path should return None."""
+        tex = load_texture(path="/tmp/nonexistent_moon.png")
+        assert tex is None
+
+
+# ── UV sampling ───────────────────────────────────────────────
+
+class TestTextureSampling:
+    """Verify bilinear-interpolated UV sampling."""
+
+    def setup_method(self):
+        self.tex = load_texture()
+        assert self.tex is not None, "Texture must load for sampling tests"
+
+    def test_sample_centre(self):
+        """Sampling at (0, 0) lon/lat should return valid RGB."""
+        r, g, b = sample_texture(0.0, 0.0, self.tex)
+        assert 0 <= r <= 255
+        assert 0 <= g <= 255
+        assert 0 <= b <= 255
+
+    def test_sample_north_pole(self):
+        """Sampling at north pole (lat=π/2) should work."""
+        r, g, b = sample_texture(0.0, np.pi / 2.0, self.tex)
+        assert 0 <= r <= 255
+        assert 0 <= g <= 255
+        assert 0 <= b <= 255
+
+    def test_sample_south_pole(self):
+        """Sampling at south pole (lat=-π/2) should work."""
+        r, g, b = sample_texture(0.0, -np.pi / 2.0, self.tex)
+        assert 0 <= r <= 255
+        assert 0 <= g <= 255
+        assert 0 <= b <= 255
+
+    def test_sample_wraps_longitude(self):
+        """Sampling at lon=π and lon=-π should give same result (seam)."""
+        _, _, b1 = sample_texture(np.pi, 0.0, self.tex)
+        _, _, b2 = sample_texture(-np.pi, 0.0, self.tex)
+        assert abs(b1 - b2) < 5, (
+            f"Seam mismatch at ±π: b={b1} vs b={b2}"
+        )
+
+    def test_sample_different_longitudes_differ(self):
+        """Different longitudes should (generally) produce different colours."""
+        r1, g1, b1 = sample_texture(-np.pi * 0.8, 0.0, self.tex)
+        r2, g2, b2 = sample_texture(np.pi * 0.8, 0.0, self.tex)
+        # The moon has bright highlands vs dark maria
+        # At ±0.8π we're near opposite limbs. They may differ.
+        assert (r1, g1, b1) != (r2, g2, b2), (
+            "Opposite limbs should have different colours"
+        )
+
+    def test_sample_mare_vs_highland(self):
+        """Mare (dark) vs highland (bright) should differ."""
+        # Mare Tranquillitatis roughly around lon=25°, lat=0°
+        mare = sample_texture(np.radians(25), 0.0, self.tex)
+        # Highlands roughly on the farside around lon=180°, lat=0°
+        highland = sample_texture(np.radians(180), 0.0, self.tex)
+        mare_brightness = sum(mare)
+        hl_brightness = sum(highland)
+        assert hl_brightness > mare_brightness - 100, (
+            f"Highlands ({hl_brightness}) should not be much "
+            f"darker than mare ({mare_brightness})"
+        )
+
+    def test_bilinear_smoothness(self):
+        """Neighbouring UV coordinates should give similar results."""
+        c1 = sample_texture(0.0, 0.0, self.tex)
+        c2 = sample_texture(0.005, 0.005, self.tex)
+        diff = sum(abs(c1[i] - c2[i]) for i in range(3))
+        assert diff < 30, f"Neighbouring samples differ too much: {diff}"
+
+    def test_returns_tuple_of_ints(self):
+        """Return value should be a tuple of three ints."""
+        result = sample_texture(0.0, 0.0, self.tex)
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        for v in result:
+            assert isinstance(v, int)
+
+
+# ── Synthetic texture (unit test) ─────────────────────────────
+
+class TestSamplingOnSyntheticTexture:
+    """Verify sampling behaviour with a known synthetic texture."""
+
+    def setup_method(self):
+        # Create a small 4×4 checkerboard texture
+        self.small_tex = np.array([
+            [[255, 0, 0], [0, 255, 0], [255, 0, 0], [0, 0, 255]],
+            [[0, 0, 255], [255, 255, 0], [0, 0, 0], [255, 255, 255]],
+            [[255, 0, 0], [0, 255, 0], [255, 0, 0], [0, 0, 255]],
+            [[0, 0, 255], [255, 255, 0], [0, 0, 0], [255, 255, 255]],
+        ], dtype=np.uint8)
+
+    def test_sample_corner(self):
+        """Sample at UV corner should be close to texel [0,0]."""
+        # Sample at the absolute corner: u≈0, v≈0 → texel [0,0]
+        # u = (lon + π)/(2π) = 0 → lon = -π
+        # v = (π/2 − lat)/π = 0 → lat = π/2
+        # At the extreme north pole + far west limb, we should get
+        # the top-left region of the texture (nev er map coordinate)
+        lon = -np.pi
+        lat = np.pi / 2.0
+        r, g, b = sample_texture(lon, lat, self.small_tex)
+        # Should be some valid interpolation of texel [0,0] but may
+        # have bilinear bleed from neighbours. Check that red dominates.
+        assert r > g + b, f"Expected red-dominant at top-left, got ({r}, {g}, {b})"
+
+    def test_sample_edge_wrap(self):
+        """Seam wrapping: u=0 and u=1 should give similar results."""
+        r1, g1, b1 = sample_texture(np.pi, 0.0, self.small_tex)
+        r2, g2, b2 = sample_texture(-np.pi, 0.0, self.small_tex)
+        assert abs(r1 - r2) < 5
+        assert abs(g1 - g2) < 5
+        assert abs(b1 - b2) < 5

--- a/tests/test_stars.py
+++ b/tests/test_stars.py
@@ -1,0 +1,308 @@
+"""Unit tests for the star rendering pipeline (stars.py).
+
+Tests cover proper motion, precession, B-V colour mapping, extinction,
+equatorial-to-horizontal conversion, and catalog loading.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from render.stars import (
+    _airmass,
+    _star_intensity,
+    _star_size,
+    apply_extinction,
+    bv_to_rgb,
+    equatorial_to_horizontal_vectorised,
+    load_catalog,
+    precess_j2000_to_epoch,
+    proper_motion,
+)
+
+
+# ── Catalog loading ───────────────────────────────────────────
+
+class TestCatalogLoading:
+    """Verify the bundled HYG catalog loads and has valid data."""
+
+    def test_loads_without_error(self):
+        """Catalog should load without raising."""
+        cat = load_catalog()
+        assert cat is not None
+
+    def test_has_required_keys(self):
+        """Catalog dict should contain all expected arrays."""
+        cat = load_catalog()
+        for key in ("id", "ra", "dec", "mag", "ci", "pmra", "pmdec"):
+            assert key in cat, f"Missing key: {key}"
+            assert isinstance(cat[key], np.ndarray)
+
+    def test_has_reasonable_number_of_stars(self):
+        """Filtered HYG should have roughly 40K stars (Vmag < 8.0)."""
+        cat = load_catalog()
+        assert 35000 < len(cat["ra"]) < 50000, (
+            f"Unexpected star count: {len(cat['ra'])}"
+        )
+
+    def test_catalog_is_cached(self):
+        """Loading twice should return the same object (cached)."""
+        cat1 = load_catalog()
+        cat2 = load_catalog()
+        assert cat1 is cat2
+
+    def test_ra_in_decimal_hours(self):
+        """RA should be in decimal hours (0-24), not degrees."""
+        cat = load_catalog()
+        assert cat["ra"].min() >= 0.0
+        assert cat["ra"].max() <= 24.0, (
+            f"RA max is {cat['ra'].max()}, expected ≤ 24 (decimal hours)"
+        )
+
+    def test_dec_in_valid_range(self):
+        """Declination should be between -90 and +90 degrees."""
+        cat = load_catalog()
+        assert cat["dec"].min() >= -90.0
+        assert cat["dec"].max() <= 90.0
+
+    def test_magnitudes_under_8(self):
+        """All stars should have Vmag < 8.0 (our filter cutoff)."""
+        cat = load_catalog()
+        assert cat["mag"].max() < 8.0
+
+    def test_ci_contains_nan(self):
+        """Some stars should have NaN colour index (missing data)."""
+        cat = load_catalog()
+        assert np.isnan(cat["ci"]).any(), "Expected some NaN CI values"
+
+
+# ── Proper motion ─────────────────────────────────────────────
+
+class TestProperMotion:
+    """Verify proper-motion correction."""
+
+    def test_no_motion_at_j2000(self):
+        """At J2000.0 epoch, proper-motion correction should be zero."""
+        ra = np.array([10.0, 100.0, 200.0])
+        dec = np.array([20.0, -30.0, 45.0])
+        pmra = np.array([100.0, 200.0, 300.0])  # mas/yr
+        pmdec = np.array([50.0, -100.0, 150.0])
+
+        ra_out, dec_out = proper_motion(ra, dec, pmra, pmdec, jd=2451545.0)
+        np.testing.assert_array_almost_equal(ra_out, ra, decimal=10)
+        np.testing.assert_array_almost_equal(dec_out, dec, decimal=10)
+
+    def test_positive_pmra_moves_west(self):
+        """Positive pmRA should increase RA when cos(dec) > 0."""
+        ra = np.array([100.0])
+        dec = np.array([0.0])  # cos = 1
+        pmra = np.array([3600000.0])  # 3600000 mas/yr = 1 deg/yr
+        pmdec = np.array([0.0])
+        # 1 year: 1 deg/yr × 1yr / 3600000 × 3600000 / cos(0) = 1 deg
+        # jd = 2451545.0 + 365.25 = 2451910.25 → delta_t = 1.0 yr
+        ra_out, _ = proper_motion(ra, dec, pmra, pmdec, jd=2451545.0 + 365.25)
+        assert abs(ra_out[0] - 101.0) < 0.1
+
+    def test_proper_motion_preserves_shape(self):
+        """Output arrays should have same shape as inputs."""
+        ra = np.array([10.0, 20.0, 30.0])
+        dec = np.array([0.0, 10.0, 20.0])
+        pmra = np.array([100.0, 200.0, 300.0])
+        pmdec = np.array([50.0, 60.0, 70.0])
+        ra_out, dec_out = proper_motion(ra, dec, pmra, pmdec, jd=2461545.0)
+        assert ra_out.shape == ra.shape
+        assert dec_out.shape == dec.shape
+
+    def test_zero_proper_motion(self):
+        """Zero proper motion should leave coordinates unchanged."""
+        ra = np.array([42.0])
+        dec = np.array([-15.0])
+        pmra = np.array([0.0])
+        pmdec = np.array([0.0])
+        ra_out, dec_out = proper_motion(ra, dec, pmra, pmdec, jd=2461545.0)
+        assert ra_out[0] == pytest.approx(42.0)
+        assert dec_out[0] == pytest.approx(-15.0)
+
+
+# ── Precession ────────────────────────────────────────────────
+
+class TestPrecession:
+    """Verify IAU 1976 precession is correctly implemented."""
+
+    def test_no_precession_at_j2000(self):
+        """At J2000.0, precession should be identity (no change)."""
+        ra = np.array([10.0, 100.0, 200.0])
+        dec = np.array([20.0, -30.0, 45.0])
+        ra_out, dec_out = precess_j2000_to_epoch(ra, dec, jd=2451545.0)
+        np.testing.assert_array_almost_equal(ra_out, ra, decimal=10)
+        np.testing.assert_array_almost_equal(dec_out, dec, decimal=10)
+
+    def test_precession_non_zero(self):
+        """After 100 years, coordinates should change measurably."""
+        ra = np.array([10.0])
+        dec = np.array([20.0])
+        ra_out, dec_out = precess_j2000_to_epoch(ra, dec, jd=2491545.0)
+        assert abs(ra_out[0] - 10.0) > 0.01
+        assert abs(dec_out[0] - 20.0) > 0.001
+
+    def test_precession_preserves_shape(self):
+        """Output should have same shape as input."""
+        ra = np.array([10.0, 20.0, 30.0])
+        dec = np.array([0.0, 10.0, 20.0])
+        ra_out, dec_out = precess_j2000_to_epoch(ra, dec, jd=2461545.0)
+        assert ra_out.shape == ra.shape
+        assert dec_out.shape == dec.shape
+
+    def test_precession_returns_valid_ra(self):
+        """Precessed RA should be in range [0, 360)."""
+        ra = np.array([100.0])
+        dec = np.array([45.0])
+        ra_out, dec_out = precess_j2000_to_epoch(ra, dec, jd=2461545.0)
+        assert 0.0 <= ra_out[0] < 360.0
+        assert -90.0 <= dec_out[0] <= 90.0
+
+
+# ── Equatorial → Horizontal ──────────────────────────────────
+
+class TestEquatorialToHorizontal:
+    """Verify alt-az conversion."""
+
+    def test_north_pole_zenith(self):
+        """At the north pole, Dec=90° should be at zenith (alt=90)."""
+        ra = np.array([0.0])
+        dec = np.array([90.0])
+        alt, az = equatorial_to_horizontal_vectorised(ra, dec, 90.0, 0.0, 2461545.0)
+        assert abs(alt[0] - 90.0) < 0.01
+
+    def test_equator_west(self):
+        """Basic sanity: reasonable altitude for a simple case."""
+        ra = np.array([30.0])
+        dec = np.array([0.0])
+        alt, az = equatorial_to_horizontal_vectorised(ra, dec, 0.0, 0.0, 2451545.0)
+        assert -90.0 <= alt[0] <= 90.0
+        assert 0.0 <= az[0] <= 360.0
+
+    def test_vectorised_output_shape(self):
+        """Multiple inputs should produce matching output shapes."""
+        ra = np.array([10.0, 50.0, 100.0, 200.0])
+        dec = np.array([10.0, 20.0, -30.0, 45.0])
+        alt, az = equatorial_to_horizontal_vectorised(ra, dec, 39.77, -86.16, 2461545.0)
+        assert alt.shape == (4,)
+        assert az.shape == (4,)
+        assert np.all(np.isfinite(alt))
+        assert np.all(np.isfinite(az))
+
+
+# ── Atmospheric extinction ────────────────────────────────────
+
+class TestAtmosphericExtinction:
+    """Verify extinction calculations."""
+
+    def test_airmass_at_zenith(self):
+        """At 90° (zenith), airmass should be ~1.0."""
+        am = _airmass(np.array([90.0]))
+        assert abs(am[0] - 1.0) < 0.01
+
+    def test_airmass_capped(self):
+        """Airmass should be capped at 10.0."""
+        am = _airmass(np.array([0.5]))
+        assert am[0] <= 10.0
+
+    def test_airmass_vectorised(self):
+        """Multiple altitudes should work and increase with lower alt."""
+        am = _airmass(np.array([30.0, 60.0, 90.0]))
+        assert am.shape == (3,)
+        assert am[2] < am[1] < am[0]
+
+    def test_extinction_increases_with_lower_altitude(self):
+        """Stars at lower altitude should have greater extinction."""
+        mag = np.array([1.0, 1.0])
+        alt = np.array([10.0, 40.0])
+        ext = apply_extinction(mag, alt)
+        assert ext[0] > ext[1]
+
+    def test_extinction_zero_at_zenith(self):
+        """At zenith, extinction should be exactly 0.28 mag."""
+        mag = np.array([0.0])
+        ext = apply_extinction(mag, np.array([90.0]))
+        assert abs(ext[0] - 0.28) < 0.01
+
+
+# ── B-V → RGB colour mapping ─────────────────────────────────
+
+class TestBvToRgb:
+    """Verify colour-index to RGB conversion."""
+
+    def test_nan_maps_to_white(self):
+        """NaN colour indices should map to white (255, 255, 255)."""
+        rgb = bv_to_rgb(np.array([np.nan]))
+        assert rgb[0].tolist() == [255, 255, 255]
+
+    def test_negative_blue(self):
+        """Negative B-V should be blue-ish."""
+        rgb = bv_to_rgb(np.array([-0.4]))
+        assert rgb[0, 2] > rgb[0, 0], f"Expected blue channel > red: {rgb[0]}"
+
+    def test_solar_yellow(self):
+        """Sun-like B-V (~0.65) should be yellow-ish."""
+        rgb = bv_to_rgb(np.array([0.65]))
+        r, g, b = rgb[0]
+        assert r > b, f"Expected red > blue for yellow star: ({r}, {g}, {b})"
+        assert abs(r - g) < 50, "R and G should be similar for yellow"
+
+    def test_red_star(self):
+        """High B-V (> 1.0) should be red-ish."""
+        rgb = bv_to_rgb(np.array([1.5]))
+        assert rgb[0, 0] > rgb[0, 2], f"Expected red > blue: {rgb[0]}"
+
+    def test_vectorised_output(self):
+        """Multiple B-V values should produce (N, 3) output."""
+        rgb = bv_to_rgb(np.array([0.0, 0.5, 1.0, np.nan]))
+        assert rgb.shape == (4, 3)
+
+    def test_rgb_in_range(self):
+        """All RGB values should be in [0, 255]."""
+        rgb = bv_to_rgb(np.array([-0.5, 0.0, 0.5, 1.0, 1.5, np.nan]))
+        assert np.all(rgb >= 0)
+        assert np.all(rgb <= 255)
+
+
+# ── Star properties from magnitude ────────────────────────────
+
+class TestStarProperties:
+    """Verify magnitude-to-size and magnitude-to-intensity mapping."""
+
+    def test_brightest_stars_largest(self):
+        """Mag < 0.5 should be size 3."""
+        sizes = _star_size(np.array([-1.5, 0.0, 0.3]))
+        assert np.all(sizes == 3)
+
+    def test_mid_stars_size_2(self):
+        """Mag 0.5-2.5 should be size 2."""
+        sizes = _star_size(np.array([0.5, 1.0, 2.0, 2.49]))
+        assert np.all(sizes == 2)
+
+    def test_dim_stars_size_1(self):
+        """Mag >= 2.5 should be size 1."""
+        sizes = _star_size(np.array([2.5, 5.0, 7.9]))
+        assert np.all(sizes == 1)
+
+    def test_intensity_decreases_with_magnitude(self):
+        """Brighter (lower mag) stars should have higher intensity."""
+        i1 = _star_intensity(np.array([0.0]))
+        i5 = _star_intensity(np.array([5.0]))
+        assert i5[0] < i1[0]
+
+    def test_sirius_intensity(self):
+        """Sirius (mag -1.44) should have intensity near 1.0."""
+        i = _star_intensity(np.array([-1.44]))
+        assert i[0] > 0.9, f"Sirius intensity too low: {i[0]}"
+
+    def test_star_sizes_vectorised(self):
+        """Multiple magnitudes should produce same-size output."""
+        sizes = _star_size(np.array([-1.0, 1.0, 5.0, 7.0]))
+        assert sizes.shape == (4,)

--- a/tests/test_visual.py
+++ b/tests/test_visual.py
@@ -26,7 +26,7 @@ class TestMoonVisibility:
     def test_moon_visible(self):
         """Moon visible at FOV=10."""
         path = render_image("v1_moon.png", lat=39.77, lon=-86.16,
-                            date="2026-04-27", time="21:00", fov=10)
+                            date="2026-04-28", time="21:00", fov=10)
         response = ask_with_retry(path, "Is there a moon visible in this image?")
         assert check_yes(response), f"Moon not detected.\nModel: {response!r}"
 
@@ -67,32 +67,79 @@ class TestAnnotations:
         assert check_yes(response), f"Annotations not detected.\nModel: {response!r}"
 
 
-# ── V5: Stars ──────────────────────────────────────────────
-class TestStars:
-    """V5: Deep night (3am) should show stars."""
+# ── V5: Moon Texture — Surface Detail ──────────────────────
+class TestMoonTexture:
+    """V5: The moon should show surface detail (craters/mares)."""
 
-    @pytest.mark.xfail(reason="moondream misses stars when large moon is present")
+    def test_moon_has_surface_detail(self):
+        """Moon surface should not be a flat solid colour — verify craters/mares visible."""
+        path = render_image("v5_moon_texture.png", lat=39.77, lon=-86.16,
+                            date="2026-04-28", time="21:00", fov=10)
+        response = ask_with_retry(path, "Does the moon in this image have visible surface features like craters or dark spots?")
+        assert check_yes(response), f"Moon surface detail not detected.\nModel: {response!r}"
+
+    def test_moon_not_solid_color(self):
+        """The moon should not appear as a uniform solid disk."""
+        path = render_image("v5_moon_not_solid.png", lat=39.77, lon=-86.16,
+                            date="2026-04-28", time="21:00", fov=10)
+        response = ask_with_retry(path, "Is the moon just a plain solid circle with no texture or detail?")
+        assert not check_yes(response), f"Moon appears as solid disk.\nModel: {response!r}"
+
+
+# ── V6: Stars — Visible in Deep Night ─────────────────────
+class TestStars:
+    """V6: Deep night (3am) should show real stars, not random dots."""
+
     def test_stars_visible_deep_night(self):
         """Stars should be visible at 3am."""
-        path = render_image("v5_stars.png", time="03:00")
+        path = render_image("v6_stars.png", time="03:00")
         response = ask_with_retry(path, "Are there stars or small white dots visible in the dark sky?")
         assert check_yes(response), f"Stars not detected.\nModel: {response!r}"
 
+    def test_stars_have_varying_brightness(self):
+        """Stars should not all be the same brightness."""
+        path = render_image("v6_stars_bright.png", time="03:00")
+        response = ask_with_retry(path, "Are there some stars that are noticeably brighter or larger than others?")
+        assert check_yes(response), f"No brightness variation in stars.\nModel: {response!r}"
 
-# ── V6: Sky Color Sanity (Wrong Sky Detection) ─────────────
+
+# ── V7: Constellation Pattern (Real Stars) ─────────────────
+class TestConstellation:
+    """V7: Real star data should produce recognisable constellations."""
+
+    @pytest.mark.xfail(reason="moondream struggles to identify specific constellations at current resolution")
+    def test_star_clustering_near_orion(self):
+        """Stars should cluster in patterns, not be uniformly random."""
+        path = render_image("v7_star_clusters.png", time="03:00", fov=90)
+        response = ask_with_retry(
+            path,
+            "Are the stars in this image scattered randomly, or do they form patterns "
+            "and clusters like actual constellations?"
+        )
+        assert "PATTERN" in response.upper() or "CLUSTER" in response.upper() or "CONSTELLATION" in response.upper(), \
+            f"Stars appear random.\nModel: {response!r}"
+
+    def test_real_stars_not_random_grid(self):
+        """Stars should not look like a grid or regular pattern."""
+        path = render_image("v7_stars_not_grid.png", time="03:00")
+        response = ask_with_retry(path, "Do the stars in this image look like a regular grid or evenly spaced pattern?")
+        assert not check_yes(response), f"Stars appear as regular grid.\nModel: {response!r}"
+
+
+# ── V8: Sky Color Sanity (Wrong Sky Detection) ─────────────
 class TestWrongSkyDetection:
-    """V6: Negative tests — model must detect contradictions."""
+    """V8: Negative tests — model must detect contradictions."""
 
     def test_daytime_sky_at_noon(self):
         """Noon render should be daytime."""
-        path = render_image("v6a_noon.png", time="12:00")
+        path = render_image("v8a_noon.png", time="12:00")
         response = ask_with_retry(path, "Describe the sky in this image. Is it bright and daytime or dark and night?")
         assert "DAY" in response.upper() or "BRIGHT" in response.upper(), \
             f"Noon sky not daytime.\nModel: {response!r}"
 
     def test_daytime_sky_not_at_3am(self):
         """3am render should NOT be daytime."""
-        path = render_image("v6b_3am_not_daytime.png", time="03:00")
+        path = render_image("v8b_3am_not_daytime.png", time="03:00")
         response = ask_with_retry(path, "Is this a daytime or night scene?")
         assert "NIGHT" in response.upper() or "DARK" in response.upper(), \
             f"3am incorrectly called daytime.\nModel: {response!r}"
@@ -100,7 +147,24 @@ class TestWrongSkyDetection:
     @pytest.mark.xfail(reason="moondream sees noon scene as 'sunrise/sunset' due to warm scattering tint")
     def test_night_sky_not_at_noon(self):
         """Noon render should NOT be night."""
-        path = render_image("v6c_noon_not_night.png", time="12:00")
+        path = render_image("v8c_noon_not_night.png", time="12:00")
         response = ask_with_retry(path, "Is this a daytime or night scene?")
         assert "DAY" in response.upper() or "BRIGHT" in response.upper(), \
             f"Noon incorrectly called night.\nModel: {response!r}"
+
+
+# ── V9: Earthshine Effect ─────────────────────────────────
+class TestEarthshine:
+    """V9: The dark side of the moon should have a subtle glow (earthshine)."""
+
+    @pytest.mark.xfail(reason="moondream cannot resolve faint earthshine on the moon's dark side at current moon sizes")
+    def test_earthshine_present_crescent(self):
+        """A thin crescent moon should show faint illumination on the dark side."""
+        path = render_image("v9_earthshine_crescent.png", lat=39.77, lon=-86.16,
+                            date="2026-04-22", time="21:00", fov=10)
+        response = ask_with_retry(
+            path,
+            "Look at the dark part of the moon. Is there a very faint glow or "
+            "faint details visible on the shadowed side?"
+        )
+        assert check_yes(response), f"Earthshine not detected.\nModel: {response!r}"


### PR DESCRIPTION
## Summary
Adds comprehensive unit tests for the two new modules (`stars.py`, `moon_texture.py`) introduced by Issues #1 and #2, plus updates visual regression tests for all new features.

## What's Added

### `tests/test_stars.py` — 36 new tests
- **Catalog loading** — validates HYG dataset has correct shape, column ranges, NaN CI
- **Proper motion** — zero motion at J2000, positive PM increases RA, shape preservation
- **Precession** — identity at J2000, measurable shift after 100yr, valid RA range output
- **Equatorial→Horizontal** — north pole zenith test, vectorised output shape
- **Atmospheric extinction** — airmass at zenith, capped min altitude, increasing with lower alt
- **B-V→RGB colour** — NaN→white, blue for negative B-V, yellow for solar value, red for high B-V
- **Star properties** — size tiers (3/2/1px), Pogson intensity, Sirius intensity

### `tests/test_moon_texture.py` — 18 new tests
- **Texture loading** — dimensions, dtype, pixel range, caching, missing-file fallback to None
- **UV sampling** — centre, poles, seam wrap at ±π, mare vs highland brightness, bilinear smoothness
- **Synthetic 4×4 texture** — UV corner mapping, seam wrapping verification

### `tests/test_visual.py` — Updated
- Moon texture surface detail tests (craters/mares visible, not a solid disk)
- Star brightness variation detection
- Constellation pattern clustering (xfail, moondream limitation noted)
- Earthshine detection on crescent moon (xfail, resolution limitation noted)
- Removed stale xfail from stars test (now working with real star data)
- Updated all dates to current (Apr 28)