### PR TITLE
Fix moon texture rotation for southern hemisphere

### DIFF
--- a/src/moon/phase.py
+++ b/src/moon/phase.py
@@ -221,3 +221,43 @@ def terminator_angle(jd: float, observer_lat_deg: float = 0.0,
         chi += q_deg
 
     return float(chi % 360.0)
+
+
+def parallactic_angle(jd: float, observer_lat_deg: float,
+                      observer_lon_deg: float) -> float:
+    """Compute the parallactic angle of the Moon at the observer's location.
+
+    The parallactic angle is the angle between the direction to celestial
+    north and the direction to the zenith, as seen by the observer.  It
+    determines how the Moon's disk appears rotated on the sky.
+
+    In the northern hemisphere the Moon appears "right-side up" (small
+    parallactic angle), while in the southern hemisphere it appears
+    rotated (large parallactic angle, approaching 180°).
+
+    :param jd: Julian Day Number
+    :param observer_lat_deg: Observer's latitude in degrees (+ = North)
+    :param observer_lon_deg: Observer's longitude in degrees (+ = East)
+    :return: Parallactic angle in degrees (-180 to 180)
+    """
+    if observer_lat_deg == 0.0:
+        return 0.0
+
+    from moon import timeconv as _tc
+    from moon import position as moonpos
+
+    moon_ra, moon_dec, _ = moonpos.moon_position(jd)
+
+    gmst_hours = _tc.gmst(jd)
+    lst_hours = _tc.lmst(gmst_hours, observer_lon_deg)
+    ha_hours = lst_hours - moon_ra / 15.0
+    ha_rad = np.radians(ha_hours * 15.0)
+
+    m_dec = np.radians(moon_dec)
+    phi_rad = np.radians(observer_lat_deg)
+
+    q_rad = np.arctan2(
+        np.sin(ha_rad),
+        np.tan(phi_rad) * np.cos(m_dec) - np.sin(m_dec) * np.cos(ha_rad)
+    )
+    return float(np.degrees(q_rad))

--- a/src/render/composite.py
+++ b/src/render/composite.py
@@ -136,6 +136,7 @@ def generate_moon_image(
     waxing = moonphase.is_waxing(sun_ra, moon_ra)
     phase_name = moonphase.phase_name(illum_frac, waxing)
     terminator_angle = moonphase.terminator_angle(jd, lat, lon)
+    parallactic_angle = moonphase.parallactic_angle(jd, lat, lon)
 
     # ---- 5. Angular diameter ----
     # Moon's angular diameter = 2 * arctan(R_moon / distance)
@@ -173,6 +174,7 @@ def generate_moon_image(
         (tint_r, tint_g, tint_b),
         moon_radius_px,
         _moon_texture,
+        parallactic_angle_deg=parallactic_angle,
     )
 
     # Position on image — center the moon when using a narrow FOV (telephoto-style)

--- a/src/render/moon_render.py
+++ b/src/render/moon_render.py
@@ -161,11 +161,14 @@ def render_moon_disk_with_texture(
     tint_rgb: Tuple[float, float, float],
     pixel_radius: int,
     texture: Optional[np.ndarray],
+    parallactic_angle_deg: float = 0.0,
 ) -> Image.Image:
     """Render the Moon disk with real surface texture and correct phase.
 
     Uses an equirectangular lunar surface texture mapped via orthographic
-    projection.  Lighting applies the atmospheric *tint* on the lit side
+    projection, rotated by *parallactic_angle_deg* so that surface
+    features appear correctly oriented for the observer's latitude.
+    Lighting applies the atmospheric *tint* on the lit side
     and a subtle blue-green earthshine on the dark side, with a smooth
     terminator blend and limb darkening.
 
@@ -181,6 +184,10 @@ def render_moon_disk_with_texture(
         pixel_radius: Moon disk radius in pixels.
         texture: ``(H, W, 3)`` uint8 equirectangular texture array, or
             ``None`` to fall back to the standard flat-colour disk.
+        parallactic_angle_deg: Parallactic angle in degrees.  The moon
+            texture is rotated by this angle so that surface features
+            appear correctly oriented for the observer's latitude.
+            Default 0.0 (northern hemisphere / equator).
 
     Returns:
         A ``(2 * pixel_radius, 2 * pixel_radius)`` RGBA image with
@@ -215,14 +222,29 @@ def render_moon_disk_with_texture(
     px = dx.astype(np.float64) / pixel_radius
     py = dy.astype(np.float64) / pixel_radius
 
+    # --- Texture rotation for observer latitude ---
+    # Rotate the (px, py) coordinates by the parallactic angle so that
+    # the moon's surface features appear correctly oriented for the
+    # observer's hemisphere (southern hemisphere → upside-down relative
+    # to northern).
+    if parallactic_angle_deg != 0.0:
+        q = math.radians(parallactic_angle_deg)
+        cos_q = math.cos(q)
+        sin_q = math.sin(q)
+        px_tex = px * cos_q - py * sin_q
+        py_tex = px * sin_q + py * cos_q
+    else:
+        px_tex = px
+        py_tex = py
+
     # --- Orthographic projection ---
     # Compute latitude and longitude for each pixel
-    # lat = arcsin(py)
-    # lon = atan2(px, sqrt(1 - px² - py²))
-    lat = np.arcsin(np.clip(py, -1.0, 1.0))
-    sq = px ** 2 + py ** 2
+    # lat = arcsin(py_tex)
+    # lon = atan2(px_tex, sqrt(1 - px_tex² - py_tex²))
+    lat = np.arcsin(np.clip(py_tex, -1.0, 1.0))
+    sq = px_tex ** 2 + py_tex ** 2
     sqrt_term = np.sqrt(np.clip(1.0 - sq, 0.0, 1.0))
-    lon = np.arctan2(px, sqrt_term)
+    lon = np.arctan2(px_tex, sqrt_term)
 
     # --- Phase (terminator) ---
     theta = math.radians(terminator_angle_deg)


### PR DESCRIPTION
## Bug Fix: Moon Texture Wrong (#9)

**Issue:** https://github.com/Josephur/Moonshot/issues/9
> "The moon texture is not rotating for southern hemisphere locations. It looks like the moon's unilluminated area does flip like it's supposed to but the texture overlay on the moon itself does not."

### Root Cause
The moon surface texture was always applied with a fixed (northern hemisphere) orientation. While the terminator angle correctly handled the observer-dependent rotation of the lit/dark boundary, the texture coordinates were not rotated to match.

### Fix
1. **New `parallactic_angle()` function** in `moon/phase.py` — computes the angle between celestial north and the observer's zenith direction, which determines how the moon appears rotated on the sky.
2. **`render_moon_disk_with_texture()`** now accepts a `parallactic_angle_deg` parameter and rotates the texture UV coordinates by this angle before sampling.
3. **`composite.py`** computes the parallactic angle and passes it through.

### Files Changed
| File | Change |
|------|--------|
| `src/moon/phase.py` | +38 lines — new `parallactic_angle()` function |
| `src/render/moon_render.py` | Modified — accept and apply parallactic rotation for texture coords |
| `src/render/composite.py` | Compute & pass parallactic angle to render function |

### Testing
✅ Renders verified for both hemispheres
✅ All 139 unit tests pass (visual tests skipped per config)

Closes #9