### PR TITLE
Fix moon glow/halo position offset (#11)

### DIFF
--- a/src/render/composite.py
+++ b/src/render/composite.py
@@ -157,9 +157,18 @@ def generate_moon_image(
 
     # ---- 7. Build image layers ----
 
-    # 7a. Sky gradient
+    # Compute moon pixel position early (needed for both sky glow and moon
+    # compositing). Center the moon when using a narrow FOV (telephoto-style).
+    _center_moon = fov_deg < 20.0
+    moon_x, moon_y = moon_position_on_image(
+        moon_app_alt, moon_az, fov_deg, image_w, image_h,
+        center_on_moon=_center_moon,
+    )
+
+    # 7a. Sky gradient (pass actual moon pixel position for correct glow)
     sky = sky_gradient(sun_alt, moon_alt, image_w, image_h,
-                         lat=lat, lon=lon, jd=jd, fov_deg=fov_deg)
+                         lat=lat, lon=lon, jd=jd, fov_deg=fov_deg,
+                         moon_px=moon_x, moon_py=moon_y)
 
     # 7b. Moon disk
     moon_radius_px = moon_size_pixels(angular_diameter, fov_deg, image_w) // 2
@@ -175,13 +184,6 @@ def generate_moon_image(
         moon_radius_px,
         _moon_texture,
         parallactic_angle_deg=parallactic_angle,
-    )
-
-    # Position on image — center the moon when using a narrow FOV (telephoto-style)
-    _center_moon = fov_deg < 20.0
-    moon_x, moon_y = moon_position_on_image(
-        moon_app_alt, moon_az, fov_deg, image_w, image_h,
-        center_on_moon=_center_moon,
     )
 
     # Composite moon onto sky

--- a/src/render/sky.py
+++ b/src/render/sky.py
@@ -253,7 +253,9 @@ def sky_gradient(sun_altitude_deg: float,
                  lat: Optional[float] = None,
                  lon: Optional[float] = None,
                  jd: Optional[float] = None,
-                 fov_deg: Optional[float] = None) -> Image.Image:
+                 fov_deg: Optional[float] = None,
+                 moon_px: Optional[int] = None,
+                 moon_py: Optional[int] = None) -> Image.Image:
     """Render a sky background image based on the Sun's altitude.
 
     Three regimes:
@@ -279,6 +281,10 @@ def sky_gradient(sun_altitude_deg: float,
         lon: Observer longitude (for real star rendering).
         jd: Julian Date of observation (for real star rendering).
         fov_deg: Vertical field-of-view in degrees (for real star rendering).
+        moon_px: Moon pixel X position (for glow placement).  If omitted
+            the position is estimated from altitude.
+        moon_py: Moon pixel Y position (for glow placement).  If omitted
+            the position is estimated from altitude.
 
     Returns:
         A new PIL ``Image`` in RGB mode of size ``(width, height)``.
@@ -298,10 +304,13 @@ def sky_gradient(sun_altitude_deg: float,
 
     # Add moon glow if the moon is above the horizon
     if moon_altitude_deg > 0.0:
-        # Estimate moon position on the image for glow placement
-        # (simplified) — positioned at a fraction of altitude.
-        moon_x = width // 2
-        moon_y = int(height * (1.0 - (moon_altitude_deg / 90.0) * 0.85))
-        sky = _add_moon_glow(sky, moon_altitude_deg, moon_x, moon_y)
+        if moon_px is not None and moon_py is not None:
+            # Use actual moon pixel position (from moon_position_on_image)
+            sky = _add_moon_glow(sky, moon_altitude_deg, moon_px, moon_py)
+        else:
+            # Fallback estimate — approximate position from altitude alone
+            moon_x = width // 2
+            moon_y = int(height * (1.0 - (moon_altitude_deg / 90.0) * 0.85))
+            sky = _add_moon_glow(sky, moon_altitude_deg, moon_x, moon_y)
 
     return sky


### PR DESCRIPTION
## Bug Fix: Moon Glow Position Wrong (#11)

**Issue:** The atmospheric glow/halo was appearing offset from the moon's actual position — often below it.

### Root Cause
The glow position was computed with a rough estimate (`moon_x = width // 2`, `moon_y = height × (1 - alt/90 × 0.85)`) which didn't account for FOV or azimuth. And this estimate was computed during `sky_gradient()` before the actual moon pixel position was determined in `composite.py`.

### Fix
1. Added optional `moon_px` / `moon_py` parameters to `sky_gradient()`
2. Moved the moon pixel position calculation (`moon_position_on_image`) **before** the sky gradient call in `composite.py`
3. Pass the actual pixel coords through so the glow renders exactly where the moon will be placed

### Files Changed
| File | Change |
|------|--------|
| `src/render/sky.py` | Added `moon_px`/ `moon_py` params to `sky_gradient()`; uses actual pos when available |
| `src/render/composite.py` | Compute moon pos before sky gradient; pass coords through |

Closes #11